### PR TITLE
Updates to new Discord invite URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A joyful meetup for people who style.
 - This is the repo for the public website https://cssclub.nyc/
 - Questions and/or want to get involved: contact@cssclub.nyc
 - Speak at CSS Club https://cssclub.nyc/cfp
-- Join our Discord https://discord.gg/hnmkbEK6
+- Join our Discord https://discord.gg/EsctDWSTwM
 
 ## Next meetup
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,7 @@
 <footer>
   <a href="/code-of-conduct">Code of conduct</a>
   <a href="/cfp">Speak at CSS Club</a>
-  <a href="https://discord.gg/hnmkbEK6">Join our Discord</a>
+  <a href="https://discord.gg/EsctDWSTwM">Join our Discord</a>
   <a href="mailto:contact@cssclub.nyc">contact@cssclub.nyc</a>
   <a href="https://github.com/cssclubnyc/cssclub.nyc">Github</a>
 </footer>

--- a/src/pages/cfp.astro
+++ b/src/pages/cfp.astro
@@ -38,7 +38,7 @@ import Layout from "@layouts/Standard.astro";
       If you have any questions or unsure about submitting a proposal, feel free
       to reach out to us by <a href="mailto:contact@cssclub.nyc"
         >contact@cssclub.nyc</a
-      > or in our <a href="https://discord.gg/hnmkbEK6">Discord</a>.
+      > or in our <a href="https://discord.gg/EsctDWSTwM">Discord</a>.
     </p>
     <div class="form-container">
       <iframe


### PR DESCRIPTION
Switched the Discord to a Community server so now we have an invite link that never expires. Updated to that in the three places we have it.